### PR TITLE
Create Maven plugin project structure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.tizuno</groupId>
+    <artifactId>spellcheck-maven-plugin</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+
+    <name>Spell Check Maven Plugin</name>
+    <description>A Maven plugin for spell-checking source files, documentation, and comments</description>
+    <url>https://github.com/t-izuno/spellcheck-maven-plugin</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.version>3.6.0</maven.version>
+        <maven-plugin-plugin.version>3.6.4</maven-plugin-plugin.version>
+    </properties>
+
+    <dependencies>
+        <!-- Maven Plugin API -->
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Maven Plugin Annotations -->
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>${maven-plugin-plugin.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Maven Core -->
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- LanguageTool for spell checking -->
+        <dependency>
+            <groupId>org.languagetool</groupId>
+            <artifactId>language-en</artifactId>
+            <version>6.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.languagetool</groupId>
+            <artifactId>languagetool-core</artifactId>
+            <version>6.3</version>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.apache.maven.plugin-testing</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <version>${maven.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Maven Compiler Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+
+            <!-- Maven Plugin Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>${maven-plugin-plugin.version}</version>
+                <configuration>
+                    <goalPrefix>spellcheck</goalPrefix>
+                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>mojo-descriptor</id>
+                        <goals>
+                            <goal>descriptor</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>help-goal</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Maven Surefire Plugin for tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+
+            <!-- Maven Invoker Plugin for integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <projectsDirectory>src/it</projectsDirectory>
+                    <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                    <pomIncludes>
+                        <pomInclude>*/pom.xml</pomInclude>
+                    </pomIncludes>
+                    <postBuildHookScript>verify</postBuildHookScript>
+                    <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+                    <settingsFile>src/it/settings.xml</settingsFile>
+                    <goals>
+                        <goal>clean</goal>
+                        <goal>verify</goal>
+                    </goals>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <goals>
+                            <goal>install</goal>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>t-izuno</id>
+            <name>T. Izuno</name>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/t-izuno/spellcheck-maven-plugin.git</connection>
+        <developerConnection>scm:git:ssh://github.com/t-izuno/spellcheck-maven-plugin.git</developerConnection>
+        <url>https://github.com/t-izuno/spellcheck-maven-plugin</url>
+    </scm>
+
+</project>

--- a/src/main/java/com/github/tizuno/maven/spellcheck/SpellCheckMojo.java
+++ b/src/main/java/com/github/tizuno/maven/spellcheck/SpellCheckMojo.java
@@ -1,0 +1,262 @@
+package com.github.tizuno.maven.spellcheck;
+
+import com.github.tizuno.maven.spellcheck.config.SpellCheckConfiguration;
+import com.github.tizuno.maven.spellcheck.report.SpellCheckReport;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Maven Mojo for spell checking source files, documentation, and comments.
+ *
+ * @author T. Izuno
+ * @since 1.0.0
+ */
+@Mojo(name = "check",
+      defaultPhase = LifecyclePhase.VERIFY,
+      requiresProject = true,
+      threadSafe = true)
+public class SpellCheckMojo extends AbstractMojo {
+
+    /**
+     * The Maven project instance.
+     */
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    /**
+     * Skip the spell check execution.
+     */
+    @Parameter(property = "spellcheck.skip", defaultValue = "false")
+    private boolean skip;
+
+    /**
+     * Fail the build on spell check errors.
+     */
+    @Parameter(property = "spellcheck.failOnError", defaultValue = "true")
+    private boolean failOnError;
+
+    /**
+     * Source file encoding.
+     */
+    @Parameter(property = "spellcheck.encoding", defaultValue = "${project.build.sourceEncoding}")
+    private String encoding;
+
+    /**
+     * File includes pattern (Ant-style).
+     */
+    @Parameter(property = "spellcheck.includes")
+    private String[] includes;
+
+    /**
+     * File excludes pattern (Ant-style).
+     */
+    @Parameter(property = "spellcheck.excludes")
+    private String[] excludes;
+
+    /**
+     * Directories to scan for files to spell check.
+     */
+    @Parameter
+    private File[] sourceDirectories;
+
+    /**
+     * Language for spell checking (e.g., "en-US", "en-GB").
+     */
+    @Parameter(property = "spellcheck.language", defaultValue = "en-US")
+    private String language;
+
+    /**
+     * Custom dictionary file containing words to ignore.
+     */
+    @Parameter(property = "spellcheck.customDictionary")
+    private File customDictionary;
+
+    /**
+     * Words to ignore during spell checking.
+     */
+    @Parameter
+    private List<String> ignoreWords;
+
+    /**
+     * Output directory for reports.
+     */
+    @Parameter(defaultValue = "${project.build.directory}/spellcheck", readonly = true)
+    private File outputDirectory;
+
+    /**
+     * Generate HTML report.
+     */
+    @Parameter(property = "spellcheck.generateReport", defaultValue = "true")
+    private boolean generateReport;
+
+    private SpellChecker spellChecker;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("Spell check is skipped.");
+            return;
+        }
+
+        getLog().info("Starting spell check...");
+        getLog().info("Language: " + language);
+        getLog().info("Encoding: " + (encoding != null ? encoding : "UTF-8"));
+
+        try {
+            // Initialize configuration
+            SpellCheckConfiguration config = createConfiguration();
+
+            // Initialize spell checker
+            spellChecker = new SpellChecker(config, getLog());
+
+            // Get files to check
+            List<File> filesToCheck = getFilesToCheck();
+
+            if (filesToCheck.isEmpty()) {
+                getLog().warn("No files found to spell check.");
+                return;
+            }
+
+            getLog().info("Checking " + filesToCheck.size() + " file(s)...");
+
+            // Perform spell checking
+            SpellCheckReport report = spellChecker.check(filesToCheck);
+
+            // Generate report if requested
+            if (generateReport) {
+                generateReport(report);
+            }
+
+            // Log summary
+            logSummary(report);
+
+            // Fail build if errors found and failOnError is true
+            if (failOnError && report.hasErrors()) {
+                throw new MojoFailureException(
+                    "Spell check found " + report.getErrorCount() + " error(s). " +
+                    "See report at: " + new File(outputDirectory, "spellcheck-report.txt").getAbsolutePath()
+                );
+            }
+
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error during spell check execution", e);
+        }
+    }
+
+    /**
+     * Creates the spell check configuration from plugin parameters.
+     */
+    private SpellCheckConfiguration createConfiguration() {
+        SpellCheckConfiguration config = new SpellCheckConfiguration();
+        config.setLanguage(language);
+        config.setEncoding(encoding != null ? encoding : "UTF-8");
+        config.setCustomDictionary(customDictionary);
+        config.setIgnoreWords(ignoreWords != null ? ignoreWords : new ArrayList<>());
+        return config;
+    }
+
+    /**
+     * Gets the list of files to spell check.
+     */
+    private List<File> getFilesToCheck() throws IOException {
+        List<File> files = new ArrayList<>();
+
+        // Determine source directories
+        List<File> dirsToScan = new ArrayList<>();
+        if (sourceDirectories != null && sourceDirectories.length > 0) {
+            for (File dir : sourceDirectories) {
+                if (dir.exists() && dir.isDirectory()) {
+                    dirsToScan.add(dir);
+                }
+            }
+        } else {
+            // Default to project source directories
+            File srcMainJava = new File(project.getBasedir(), "src/main/java");
+            File srcTestJava = new File(project.getBasedir(), "src/test/java");
+            File srcMainResources = new File(project.getBasedir(), "src/main/resources");
+
+            if (srcMainJava.exists()) dirsToScan.add(srcMainJava);
+            if (srcTestJava.exists()) dirsToScan.add(srcTestJava);
+            if (srcMainResources.exists()) dirsToScan.add(srcMainResources);
+
+            // Check for README and markdown files in root
+            File readme = new File(project.getBasedir(), "README.md");
+            if (readme.exists()) files.add(readme);
+        }
+
+        // Scan directories and collect files
+        for (File dir : dirsToScan) {
+            try (Stream<Path> paths = Files.walk(dir.toPath())) {
+                paths.filter(Files::isRegularFile)
+                     .filter(this::shouldCheckFile)
+                     .forEach(p -> files.add(p.toFile()));
+            }
+        }
+
+        return files;
+    }
+
+    /**
+     * Determines if a file should be checked based on includes/excludes patterns.
+     */
+    private boolean shouldCheckFile(Path path) {
+        String fileName = path.getFileName().toString();
+
+        // Default file types to check
+        if (fileName.endsWith(".java") ||
+            fileName.endsWith(".md") ||
+            fileName.endsWith(".txt") ||
+            fileName.endsWith(".properties") ||
+            fileName.endsWith(".xml")) {
+            return true;
+        }
+
+        // TODO: Implement proper Ant-style pattern matching for includes/excludes
+        return false;
+    }
+
+    /**
+     * Generates the spell check report.
+     */
+    private void generateReport(SpellCheckReport report) throws IOException {
+        if (!outputDirectory.exists()) {
+            outputDirectory.mkdirs();
+        }
+
+        File reportFile = new File(outputDirectory, "spellcheck-report.txt");
+        report.writeToFile(reportFile);
+
+        getLog().info("Report generated at: " + reportFile.getAbsolutePath());
+    }
+
+    /**
+     * Logs the spell check summary.
+     */
+    private void logSummary(SpellCheckReport report) {
+        getLog().info("========================================");
+        getLog().info("Spell Check Summary");
+        getLog().info("========================================");
+        getLog().info("Files checked: " + report.getFilesChecked());
+        getLog().info("Errors found: " + report.getErrorCount());
+
+        if (report.hasErrors()) {
+            getLog().warn("Spell check completed with errors!");
+        } else {
+            getLog().info("Spell check completed successfully!");
+        }
+        getLog().info("========================================");
+    }
+}

--- a/src/main/java/com/github/tizuno/maven/spellcheck/SpellChecker.java
+++ b/src/main/java/com/github/tizuno/maven/spellcheck/SpellChecker.java
@@ -1,0 +1,190 @@
+package com.github.tizuno.maven.spellcheck;
+
+import com.github.tizuno.maven.spellcheck.config.SpellCheckConfiguration;
+import com.github.tizuno.maven.spellcheck.report.SpellCheckReport;
+import com.github.tizuno.maven.spellcheck.report.SpellError;
+import org.apache.maven.plugin.logging.Log;
+import org.languagetool.JLanguageTool;
+import org.languagetool.language.AmericanEnglish;
+import org.languagetool.language.BritishEnglish;
+import org.languagetool.rules.RuleMatch;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.List;
+
+/**
+ * Core spell checker implementation using LanguageTool.
+ *
+ * @author T. Izuno
+ * @since 1.0.0
+ */
+public class SpellChecker {
+
+    private final SpellCheckConfiguration config;
+    private final Log log;
+    private final JLanguageTool languageTool;
+
+    /**
+     * Creates a new spell checker with the given configuration.
+     *
+     * @param config the spell check configuration
+     * @param log    the Maven logger
+     * @throws IOException if initialization fails
+     */
+    public SpellChecker(SpellCheckConfiguration config, Log log) throws IOException {
+        this.config = config;
+        this.log = log;
+        this.languageTool = createLanguageTool(config.getLanguage());
+
+        // Add custom words to ignore
+        if (config.getCustomDictionary() != null && config.getCustomDictionary().exists()) {
+            loadCustomDictionary(config.getCustomDictionary());
+        }
+
+        // Add ignore words
+        for (String word : config.getIgnoreWords()) {
+            languageTool.addIgnoreTokens(java.util.Collections.singletonList(word));
+        }
+    }
+
+    /**
+     * Creates a JLanguageTool instance for the specified language.
+     *
+     * @param language the language code
+     * @return the JLanguageTool instance
+     */
+    private JLanguageTool createLanguageTool(String language) {
+        if (language == null || language.startsWith("en-US")) {
+            return new JLanguageTool(new AmericanEnglish());
+        } else if (language.startsWith("en-GB")) {
+            return new JLanguageTool(new BritishEnglish());
+        } else {
+            // Default to American English
+            log.warn("Unsupported language: " + language + ". Defaulting to en-US.");
+            return new JLanguageTool(new AmericanEnglish());
+        }
+    }
+
+    /**
+     * Loads custom dictionary words.
+     *
+     * @param dictionaryFile the dictionary file
+     * @throws IOException if reading fails
+     */
+    private void loadCustomDictionary(File dictionaryFile) throws IOException {
+        log.debug("Loading custom dictionary from: " + dictionaryFile.getAbsolutePath());
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(dictionaryFile))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (!line.isEmpty() && !line.startsWith("#")) {
+                    languageTool.addIgnoreTokens(java.util.Collections.singletonList(line));
+                }
+            }
+        }
+
+        log.debug("Custom dictionary loaded successfully");
+    }
+
+    /**
+     * Checks the given files for spelling errors.
+     *
+     * @param files the files to check
+     * @return the spell check report
+     * @throws IOException if file reading fails
+     */
+    public SpellCheckReport check(List<File> files) throws IOException {
+        SpellCheckReport report = new SpellCheckReport();
+
+        for (File file : files) {
+            log.debug("Checking file: " + file.getAbsolutePath());
+            checkFile(file, report);
+        }
+
+        return report;
+    }
+
+    /**
+     * Checks a single file for spelling errors.
+     *
+     * @param file   the file to check
+     * @param report the report to update
+     * @throws IOException if file reading fails
+     */
+    private void checkFile(File file, SpellCheckReport report) throws IOException {
+        report.incrementFilesChecked();
+
+        String content = readFile(file);
+
+        if (content.trim().isEmpty()) {
+            log.debug("Skipping empty file: " + file.getName());
+            return;
+        }
+
+        try {
+            List<RuleMatch> matches = languageTool.check(content);
+
+            for (RuleMatch match : matches) {
+                // Only report spelling errors, not grammar errors
+                if (isSpellingError(match)) {
+                    SpellError error = new SpellError(
+                        file,
+                        match.getLine() + 1,
+                        match.getColumn() + 1,
+                        content.substring(match.getFromPos(), match.getToPos()),
+                        match.getMessage(),
+                        match.getSuggestedReplacements()
+                    );
+
+                    report.addError(error);
+
+                    if (log.isDebugEnabled()) {
+                        log.debug(String.format(
+                            "Error in %s at line %d: %s",
+                            file.getName(),
+                            error.getLine(),
+                            error.getWord()
+                        ));
+                    }
+                }
+            }
+
+        } catch (Exception e) {
+            log.warn("Error checking file " + file.getName() + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Reads the content of a file.
+     *
+     * @param file the file to read
+     * @return the file content
+     * @throws IOException if reading fails
+     */
+    private String readFile(File file) throws IOException {
+        Charset charset = Charset.forName(config.getEncoding());
+        byte[] bytes = Files.readAllBytes(file.toPath());
+        return new String(bytes, charset);
+    }
+
+    /**
+     * Determines if a rule match is a spelling error.
+     *
+     * @param match the rule match
+     * @return true if it's a spelling error
+     */
+    private boolean isSpellingError(RuleMatch match) {
+        String ruleId = match.getRule().getId();
+        // Check if it's a spelling-related rule
+        return ruleId.contains("SPELL") ||
+               ruleId.contains("MORFOLOGIK") ||
+               ruleId.contains("HUNSPELL") ||
+               ruleId.contains("TYPO");
+    }
+}

--- a/src/main/java/com/github/tizuno/maven/spellcheck/config/SpellCheckConfiguration.java
+++ b/src/main/java/com/github/tizuno/maven/spellcheck/config/SpellCheckConfiguration.java
@@ -1,0 +1,91 @@
+package com.github.tizuno.maven.spellcheck.config;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Configuration for spell checking.
+ *
+ * @author T. Izuno
+ * @since 1.0.0
+ */
+public class SpellCheckConfiguration {
+
+    private String language = "en-US";
+    private String encoding = "UTF-8";
+    private File customDictionary;
+    private List<String> ignoreWords = new ArrayList<>();
+
+    /**
+     * Gets the language for spell checking.
+     *
+     * @return the language code (e.g., "en-US")
+     */
+    public String getLanguage() {
+        return language;
+    }
+
+    /**
+     * Sets the language for spell checking.
+     *
+     * @param language the language code
+     */
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    /**
+     * Gets the file encoding.
+     *
+     * @return the encoding
+     */
+    public String getEncoding() {
+        return encoding;
+    }
+
+    /**
+     * Sets the file encoding.
+     *
+     * @param encoding the encoding
+     */
+    public void setEncoding(String encoding) {
+        this.encoding = encoding;
+    }
+
+    /**
+     * Gets the custom dictionary file.
+     *
+     * @return the custom dictionary file
+     */
+    public File getCustomDictionary() {
+        return customDictionary;
+    }
+
+    /**
+     * Sets the custom dictionary file.
+     *
+     * @param customDictionary the custom dictionary file
+     */
+    public void setCustomDictionary(File customDictionary) {
+        this.customDictionary = customDictionary;
+    }
+
+    /**
+     * Gets the list of words to ignore.
+     *
+     * @return the list of ignored words
+     */
+    public List<String> getIgnoreWords() {
+        return ignoreWords;
+    }
+
+    /**
+     * Sets the list of words to ignore.
+     *
+     * @param ignoreWords the list of ignored words
+     */
+    public void setIgnoreWords(List<String> ignoreWords) {
+        this.ignoreWords = ignoreWords;
+    }
+}

--- a/src/main/java/com/github/tizuno/maven/spellcheck/report/SpellCheckReport.java
+++ b/src/main/java/com/github/tizuno/maven/spellcheck/report/SpellCheckReport.java
@@ -1,0 +1,148 @@
+package com.github.tizuno.maven.spellcheck.report;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Report containing all spell check results.
+ *
+ * @author T. Izuno
+ * @since 1.0.0
+ */
+public class SpellCheckReport {
+
+    private int filesChecked = 0;
+    private final List<SpellError> errors = new ArrayList<>();
+    private final Map<File, List<SpellError>> errorsByFile = new HashMap<>();
+
+    /**
+     * Increments the count of files checked.
+     */
+    public void incrementFilesChecked() {
+        filesChecked++;
+    }
+
+    /**
+     * Adds a spell error to the report.
+     *
+     * @param error the spell error
+     */
+    public void addError(SpellError error) {
+        errors.add(error);
+        errorsByFile.computeIfAbsent(error.getFile(), k -> new ArrayList<>()).add(error);
+    }
+
+    /**
+     * Gets the number of files checked.
+     *
+     * @return the number of files
+     */
+    public int getFilesChecked() {
+        return filesChecked;
+    }
+
+    /**
+     * Gets the total number of errors found.
+     *
+     * @return the error count
+     */
+    public int getErrorCount() {
+        return errors.size();
+    }
+
+    /**
+     * Checks if any errors were found.
+     *
+     * @return true if errors exist
+     */
+    public boolean hasErrors() {
+        return !errors.isEmpty();
+    }
+
+    /**
+     * Gets all errors.
+     *
+     * @return the list of errors
+     */
+    public List<SpellError> getErrors() {
+        return new ArrayList<>(errors);
+    }
+
+    /**
+     * Gets errors grouped by file.
+     *
+     * @return map of file to errors
+     */
+    public Map<File, List<SpellError>> getErrorsByFile() {
+        return new HashMap<>(errorsByFile);
+    }
+
+    /**
+     * Writes the report to a text file.
+     *
+     * @param outputFile the output file
+     * @throws IOException if writing fails
+     */
+    public void writeToFile(File outputFile) throws IOException {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(outputFile))) {
+            writer.write("Spell Check Report");
+            writer.newLine();
+            writer.write("==================");
+            writer.newLine();
+            writer.newLine();
+
+            writer.write("Files checked: " + filesChecked);
+            writer.newLine();
+            writer.write("Errors found: " + errors.size());
+            writer.newLine();
+            writer.newLine();
+
+            if (errors.isEmpty()) {
+                writer.write("No spelling errors found!");
+                writer.newLine();
+            } else {
+                writer.write("Errors by file:");
+                writer.newLine();
+                writer.write("---------------");
+                writer.newLine();
+                writer.newLine();
+
+                for (Map.Entry<File, List<SpellError>> entry : errorsByFile.entrySet()) {
+                    writer.write(entry.getKey().getPath());
+                    writer.newLine();
+
+                    for (SpellError error : entry.getValue()) {
+                        writer.write("  Line " + error.getLine() +
+                                   ", Column " + error.getColumn() +
+                                   ": '" + error.getWord() + "'");
+                        writer.newLine();
+                        writer.write("    " + error.getMessage());
+                        writer.newLine();
+
+                        if (error.getSuggestions() != null && !error.getSuggestions().isEmpty()) {
+                            writer.write("    Suggestions: " +
+                                       String.join(", ",
+                                           error.getSuggestions().subList(0, Math.min(5, error.getSuggestions().size()))));
+                            writer.newLine();
+                        }
+                        writer.newLine();
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "SpellCheckReport{" +
+               "filesChecked=" + filesChecked +
+               ", errorCount=" + errors.size() +
+               '}';
+    }
+}

--- a/src/main/java/com/github/tizuno/maven/spellcheck/report/SpellError.java
+++ b/src/main/java/com/github/tizuno/maven/spellcheck/report/SpellError.java
@@ -1,0 +1,111 @@
+package com.github.tizuno.maven.spellcheck.report;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Represents a single spelling error.
+ *
+ * @author T. Izuno
+ * @since 1.0.0
+ */
+public class SpellError {
+
+    private final File file;
+    private final int line;
+    private final int column;
+    private final String word;
+    private final String message;
+    private final List<String> suggestions;
+
+    /**
+     * Creates a new spell error.
+     *
+     * @param file        the file containing the error
+     * @param line        the line number (1-based)
+     * @param column      the column number (1-based)
+     * @param word        the misspelled word
+     * @param message     the error message
+     * @param suggestions suggested corrections
+     */
+    public SpellError(File file, int line, int column, String word, String message, List<String> suggestions) {
+        this.file = file;
+        this.line = line;
+        this.column = column;
+        this.word = word;
+        this.message = message;
+        this.suggestions = suggestions;
+    }
+
+    /**
+     * Gets the file containing the error.
+     *
+     * @return the file
+     */
+    public File getFile() {
+        return file;
+    }
+
+    /**
+     * Gets the line number.
+     *
+     * @return the line number (1-based)
+     */
+    public int getLine() {
+        return line;
+    }
+
+    /**
+     * Gets the column number.
+     *
+     * @return the column number (1-based)
+     */
+    public int getColumn() {
+        return column;
+    }
+
+    /**
+     * Gets the misspelled word.
+     *
+     * @return the word
+     */
+    public String getWord() {
+        return word;
+    }
+
+    /**
+     * Gets the error message.
+     *
+     * @return the message
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * Gets the suggested corrections.
+     *
+     * @return the list of suggestions
+     */
+    public List<String> getSuggestions() {
+        return suggestions;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(file.getPath()).append(":")
+          .append(line).append(":")
+          .append(column).append(": ")
+          .append("'").append(word).append("' - ")
+          .append(message);
+
+        if (suggestions != null && !suggestions.isEmpty()) {
+            sb.append(" [Suggestions: ");
+            sb.append(String.join(", ", suggestions.subList(0, Math.min(3, suggestions.size()))));
+            sb.append("]");
+        }
+
+        return sb.toString();
+    }
+}

--- a/src/test/java/com/github/tizuno/maven/spellcheck/SpellCheckMojoTest.java
+++ b/src/test/java/com/github/tizuno/maven/spellcheck/SpellCheckMojoTest.java
@@ -1,0 +1,52 @@
+package com.github.tizuno.maven.spellcheck;
+
+import org.apache.maven.plugin.testing.MojoRule;
+import org.apache.maven.plugin.testing.WithoutMojo;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for SpellCheckMojo.
+ *
+ * @author T. Izuno
+ */
+public class SpellCheckMojoTest {
+
+    @Rule
+    public MojoRule rule = new MojoRule() {
+        @Override
+        protected void before() throws Throwable {
+        }
+
+        @Override
+        protected void after() {
+        }
+    };
+
+    /**
+     * Tests that the Mojo can be instantiated.
+     */
+    @Test
+    @WithoutMojo
+    public void testMojoInstantiation() {
+        SpellCheckMojo mojo = new SpellCheckMojo();
+        assertNotNull(mojo);
+    }
+
+    /**
+     * Tests skip functionality.
+     */
+    @Test
+    public void testSkipExecution() throws Exception {
+        File pom = new File("src/test/resources/test-projects/simple-project/pom.xml");
+        assertNotNull(pom);
+        assertTrue(pom.exists());
+
+        // This is a basic test to ensure the test infrastructure is working
+        // More comprehensive tests would require a proper test project setup
+    }
+}

--- a/src/test/java/com/github/tizuno/maven/spellcheck/report/SpellCheckReportTest.java
+++ b/src/test/java/com/github/tizuno/maven/spellcheck/report/SpellCheckReportTest.java
@@ -1,0 +1,122 @@
+package com.github.tizuno.maven.spellcheck.report;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for SpellCheckReport.
+ *
+ * @author T. Izuno
+ */
+public class SpellCheckReportTest {
+
+    private SpellCheckReport report;
+    private File testFile;
+
+    @Before
+    public void setUp() {
+        report = new SpellCheckReport();
+        testFile = new File("TestFile.java");
+    }
+
+    @Test
+    public void testInitialState() {
+        assertEquals(0, report.getFilesChecked());
+        assertEquals(0, report.getErrorCount());
+        assertFalse(report.hasErrors());
+    }
+
+    @Test
+    public void testIncrementFilesChecked() {
+        report.incrementFilesChecked();
+        assertEquals(1, report.getFilesChecked());
+
+        report.incrementFilesChecked();
+        assertEquals(2, report.getFilesChecked());
+    }
+
+    @Test
+    public void testAddError() {
+        List<String> suggestions = Arrays.asList("correct", "correkt");
+        SpellError error = new SpellError(testFile, 10, 5, "incorect", "Possible spelling mistake", suggestions);
+
+        report.addError(error);
+
+        assertEquals(1, report.getErrorCount());
+        assertTrue(report.hasErrors());
+        assertEquals(1, report.getErrors().size());
+        assertEquals(error, report.getErrors().get(0));
+    }
+
+    @Test
+    public void testMultipleErrors() {
+        SpellError error1 = new SpellError(testFile, 10, 5, "incorect", "Spelling mistake", Arrays.asList("correct"));
+        SpellError error2 = new SpellError(testFile, 15, 8, "teh", "Spelling mistake", Arrays.asList("the"));
+
+        report.addError(error1);
+        report.addError(error2);
+
+        assertEquals(2, report.getErrorCount());
+        assertTrue(report.hasErrors());
+    }
+
+    @Test
+    public void testErrorsByFile() {
+        File file1 = new File("File1.java");
+        File file2 = new File("File2.java");
+
+        SpellError error1 = new SpellError(file1, 10, 5, "incorect", "Spelling mistake", Arrays.asList("correct"));
+        SpellError error2 = new SpellError(file1, 15, 8, "teh", "Spelling mistake", Arrays.asList("the"));
+        SpellError error3 = new SpellError(file2, 5, 1, "speling", "Spelling mistake", Arrays.asList("spelling"));
+
+        report.addError(error1);
+        report.addError(error2);
+        report.addError(error3);
+
+        assertEquals(2, report.getErrorsByFile().get(file1).size());
+        assertEquals(1, report.getErrorsByFile().get(file2).size());
+    }
+
+    @Test
+    public void testWriteToFile() throws IOException {
+        File outputFile = Files.createTempFile("spellcheck-test", ".txt").toFile();
+        outputFile.deleteOnExit();
+
+        report.incrementFilesChecked();
+        report.incrementFilesChecked();
+
+        SpellError error = new SpellError(testFile, 10, 5, "incorect", "Possible spelling mistake",
+                                         Arrays.asList("correct", "incorrect"));
+        report.addError(error);
+
+        report.writeToFile(outputFile);
+
+        assertTrue(outputFile.exists());
+        assertTrue(outputFile.length() > 0);
+
+        String content = new String(Files.readAllBytes(outputFile.toPath()));
+        assertTrue(content.contains("Files checked: 2"));
+        assertTrue(content.contains("Errors found: 1"));
+        assertTrue(content.contains("incorect"));
+    }
+
+    @Test
+    public void testWriteEmptyReport() throws IOException {
+        File outputFile = Files.createTempFile("spellcheck-empty", ".txt").toFile();
+        outputFile.deleteOnExit();
+
+        report.incrementFilesChecked();
+        report.writeToFile(outputFile);
+
+        String content = new String(Files.readAllBytes(outputFile.toPath()));
+        assertTrue(content.contains("No spelling errors found!"));
+    }
+}

--- a/src/test/resources/test-projects/simple-project/pom.xml
+++ b/src/test/resources/test-projects/simple-project/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.tizuno.test</groupId>
+    <artifactId>simple-project</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.tizuno</groupId>
+                <artifactId>spellcheck-maven-plugin</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Implement initial Maven plugin project with the following components:

- Maven plugin project structure with pom.xml
- SpellCheckMojo: Main Mojo class for spell checking
- SpellChecker: Core spell checking logic using LanguageTool
- SpellCheckConfiguration: Configuration model for plugin parameters
- SpellCheckReport and SpellError: Reporting components
- Unit tests for Mojo and Report classes
- Test resources for integration testing

The plugin integrates with Maven build lifecycle and provides spell checking capabilities for source files, documentation, and comments in Maven projects.