### PR TITLE
Add cspell-style configuration file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,225 @@
 # spellcheck-maven-plugin
+
+A Maven plugin for spell-checking source files, documentation, and comments in your Maven projects.
+
+## Features
+
+- Spell-checking for Java source files, documentation, and other text files
+- Support for CSpell configuration files (`cspell.json`, `.cspell.json`)
+- Customizable dictionaries and ignore words
+- Integration with Maven build lifecycle
+- Configurable file patterns for inclusion and exclusion
+- Detailed reporting of spelling errors
+
+## Usage
+
+### Basic Configuration
+
+Add the plugin to your `pom.xml`:
+
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <groupId>com.github.tizuno</groupId>
+            <artifactId>spellcheck-maven-plugin</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>check</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+</build>
+```
+
+### CSpell Configuration File Support
+
+The plugin automatically detects and uses CSpell configuration files in your project root. Supported filenames:
+- `cspell.json`
+- `.cspell.json`
+- `cSpell.json`
+- `.cSpell.json`
+
+#### Example CSpell Configuration
+
+Create a `cspell.json` file in your project root:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
+  "version": "0.2",
+  "language": "en-US",
+  "words": [
+    "spellcheck",
+    "customword"
+  ],
+  "ignoreWords": [
+    "TODO",
+    "FIXME"
+  ],
+  "ignorePaths": [
+    "node_modules/**",
+    "target/**",
+    "*.min.js"
+  ],
+  "files": [
+    "**/*.java",
+    "**/*.md",
+    "**/*.txt"
+  ]
+}
+```
+
+See [`cspell.json.example`](cspell.json.example) for a complete example.
+
+### Plugin Configuration Options
+
+You can configure the plugin in your `pom.xml`:
+
+```xml
+<plugin>
+    <groupId>com.github.tizuno</groupId>
+    <artifactId>spellcheck-maven-plugin</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <configuration>
+        <!-- Enable/disable CSpell config file detection -->
+        <useCSpellConfig>true</useCSpellConfig>
+
+        <!-- Specify custom CSpell config file path -->
+        <cspellConfigFile>${project.basedir}/custom-cspell.json</cspellConfigFile>
+
+        <!-- Language for spell checking (overrides CSpell config) -->
+        <language>en-US</language>
+
+        <!-- File encoding -->
+        <encoding>UTF-8</encoding>
+
+        <!-- Custom dictionary file -->
+        <customDictionary>${project.basedir}/custom-dictionary.txt</customDictionary>
+
+        <!-- Words to ignore (merged with CSpell config) -->
+        <ignoreWords>
+            <ignoreWord>customword1</ignoreWord>
+            <ignoreWord>customword2</ignoreWord>
+        </ignoreWords>
+
+        <!-- Fail build on errors -->
+        <failOnError>true</failOnError>
+
+        <!-- Skip spell check -->
+        <skip>false</skip>
+
+        <!-- Generate report -->
+        <generateReport>true</generateReport>
+    </configuration>
+</plugin>
+```
+
+### Command Line Usage
+
+Run spell check manually:
+
+```bash
+mvn spellcheck:check
+```
+
+Skip spell check:
+
+```bash
+mvn verify -Dspellcheck.skip=true
+```
+
+Don't fail build on errors:
+
+```bash
+mvn verify -Dspellcheck.failOnError=false
+```
+
+Specify custom CSpell config:
+
+```bash
+mvn spellcheck:check -Dspellcheck.cspellConfig=path/to/cspell.json
+```
+
+Disable CSpell config file detection:
+
+```bash
+mvn spellcheck:check -Dspellcheck.useCSpellConfig=false
+```
+
+## CSpell Integration
+
+### Supported CSpell Features
+
+The plugin supports the following CSpell configuration properties:
+
+- `version`: Configuration format version
+- `language`: Language locale(s) for spell checking
+- `words`: List of words to be considered correct
+- `ignoreWords`: List of words to be ignored
+- `ignorePaths`: Glob patterns of files to be ignored
+- `files`: Glob patterns of files to be checked
+- `dictionaries`: List of dictionaries to use
+- `dictionaryDefinitions`: Custom dictionary definitions
+- `patterns`: Named patterns for regex matching
+- `ignoreRegExpList`: Regular expressions to exclude from checking
+- `includeRegExpList`: Regular expressions to include in checking
+- `import`: Import other CSpell configuration files
+- `enabled`: Enable/disable spell checking
+- `caseSensitive`: Case-sensitive matching
+- `allowCompoundWords`: Allow compound words
+- `flagWords`: Words that are always considered incorrect
+- `overrides`: File-specific configuration overrides
+
+### Configuration Priority
+
+When both CSpell configuration file and Maven plugin configuration are present:
+
+1. CSpell configuration file is loaded first (if `useCSpellConfig=true`)
+2. Maven plugin parameters override CSpell settings
+3. For list properties (like `ignoreWords`), both are merged
+
+### Import Support
+
+The plugin supports CSpell's `import` feature to load configuration from other files:
+
+```json
+{
+  "version": "0.2",
+  "import": [
+    "./base-cspell.json",
+    "../shared-config.json"
+  ],
+  "words": [
+    "projectspecific"
+  ]
+}
+```
+
+## Reports
+
+The plugin generates a spell check report in the `target/spellcheck` directory:
+- `spellcheck-report.txt`: Text report with all spelling errors
+
+## Requirements
+
+- Java 8 or higher
+- Maven 3.6.0 or higher
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit issues or pull requests.
+
+## Links
+
+- [CSpell Documentation](https://cspell.org/)
+- [CSpell Configuration](https://cspell.org/configuration/)
+- [Maven Plugin Development](https://maven.apache.org/plugin-developers/)

--- a/cspell.json.example
+++ b/cspell.json.example
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
+  "version": "0.2",
+  "language": "en-US",
+  "words": [
+    "spellcheck",
+    "Mojo",
+    "plugin",
+    "Maven"
+  ],
+  "ignoreWords": [
+    "TODO",
+    "FIXME"
+  ],
+  "ignorePaths": [
+    "node_modules/**",
+    "target/**",
+    "*.min.js",
+    "*.map"
+  ],
+  "files": [
+    "**/*.java",
+    "**/*.md",
+    "**/*.txt"
+  ],
+  "dictionaries": [
+    "java",
+    "maven"
+  ],
+  "ignoreRegExpList": [
+    "/\\b[A-Z]{2,}\\b/g",
+    "/0x[0-9a-fA-F]+/g"
+  ],
+  "enabled": true,
+  "allowCompoundWords": false,
+  "caseSensitive": false
+}

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,13 @@
             <version>6.3</version>
         </dependency>
 
+        <!-- Jackson for JSON processing -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.3</version>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
@@ -72,6 +79,13 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.12.4</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/github/tizuno/maven/spellcheck/config/CSpellConfig.java
+++ b/src/main/java/com/github/tizuno/maven/spellcheck/config/CSpellConfig.java
@@ -1,0 +1,450 @@
+package com.github.tizuno.maven.spellcheck.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Configuration model for CSpell-compatible configuration files.
+ * This class represents the structure of cspell.json or .cspell.json files.
+ *
+ * @author T. Izuno
+ * @since 1.0.0
+ * @see <a href="https://cspell.org/configuration/">CSpell Configuration</a>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CSpellConfig {
+
+    /**
+     * Configuration format version (e.g., "0.2").
+     */
+    @JsonProperty("version")
+    private String version;
+
+    /**
+     * Language locale(s) to use for spell checking (e.g., "en", "en-US", "en,nl").
+     */
+    @JsonProperty("language")
+    private String language;
+
+    /**
+     * List of words to be considered correct.
+     */
+    @JsonProperty("words")
+    private List<String> words;
+
+    /**
+     * List of words to be ignored. An ignored word will not show up as an error.
+     */
+    @JsonProperty("ignoreWords")
+    private List<String> ignoreWords;
+
+    /**
+     * Glob patterns of files to be ignored.
+     */
+    @JsonProperty("ignorePaths")
+    private List<String> ignorePaths;
+
+    /**
+     * Glob patterns of files to be checked.
+     */
+    @JsonProperty("files")
+    private List<String> files;
+
+    /**
+     * Optional list of dictionaries to use.
+     */
+    @JsonProperty("dictionaries")
+    private List<String> dictionaries;
+
+    /**
+     * Defines custom available dictionaries.
+     */
+    @JsonProperty("dictionaryDefinitions")
+    private List<DictionaryDefinition> dictionaryDefinitions;
+
+    /**
+     * List of patterns that can be used with ignoreRegExpList and includeRegExpList.
+     */
+    @JsonProperty("patterns")
+    private List<Pattern> patterns;
+
+    /**
+     * Regular expression patterns to exclude from spell checking.
+     */
+    @JsonProperty("ignoreRegExpList")
+    private List<String> ignoreRegExpList;
+
+    /**
+     * Patterns to match for spell checking.
+     */
+    @JsonProperty("includeRegExpList")
+    private List<String> includeRegExpList;
+
+    /**
+     * Allows this configuration to inherit configuration from other files.
+     */
+    @JsonProperty("import")
+    private List<String> importPaths;
+
+    /**
+     * Enables or disables the spell checker.
+     */
+    @JsonProperty("enabled")
+    private Boolean enabled;
+
+    /**
+     * Enable scanning of hidden files and directories (starting with ".").
+     */
+    @JsonProperty("enableGlobDot")
+    private Boolean enableGlobDot;
+
+    /**
+     * Determines if words must match case and accent rules.
+     */
+    @JsonProperty("caseSensitive")
+    private Boolean caseSensitive;
+
+    /**
+     * Enables compound word checking.
+     */
+    @JsonProperty("allowCompoundWords")
+    private Boolean allowCompoundWords;
+
+    /**
+     * Words that are always considered incorrect.
+     */
+    @JsonProperty("flagWords")
+    private List<String> flagWords;
+
+    /**
+     * Root directory for glob patterns.
+     */
+    @JsonProperty("globRoot")
+    private String globRoot;
+
+    /**
+     * Apply settings to specific files in the project.
+     */
+    @JsonProperty("overrides")
+    private List<Override> overrides;
+
+    // Constructors
+
+    public CSpellConfig() {
+        this.words = new ArrayList<>();
+        this.ignoreWords = new ArrayList<>();
+        this.ignorePaths = new ArrayList<>();
+        this.files = new ArrayList<>();
+        this.dictionaries = new ArrayList<>();
+        this.dictionaryDefinitions = new ArrayList<>();
+        this.patterns = new ArrayList<>();
+        this.ignoreRegExpList = new ArrayList<>();
+        this.includeRegExpList = new ArrayList<>();
+        this.importPaths = new ArrayList<>();
+        this.flagWords = new ArrayList<>();
+        this.overrides = new ArrayList<>();
+    }
+
+    // Getters and Setters
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public List<String> getWords() {
+        return words;
+    }
+
+    public void setWords(List<String> words) {
+        this.words = words;
+    }
+
+    public List<String> getIgnoreWords() {
+        return ignoreWords;
+    }
+
+    public void setIgnoreWords(List<String> ignoreWords) {
+        this.ignoreWords = ignoreWords;
+    }
+
+    public List<String> getIgnorePaths() {
+        return ignorePaths;
+    }
+
+    public void setIgnorePaths(List<String> ignorePaths) {
+        this.ignorePaths = ignorePaths;
+    }
+
+    public List<String> getFiles() {
+        return files;
+    }
+
+    public void setFiles(List<String> files) {
+        this.files = files;
+    }
+
+    public List<String> getDictionaries() {
+        return dictionaries;
+    }
+
+    public void setDictionaries(List<String> dictionaries) {
+        this.dictionaries = dictionaries;
+    }
+
+    public List<DictionaryDefinition> getDictionaryDefinitions() {
+        return dictionaryDefinitions;
+    }
+
+    public void setDictionaryDefinitions(List<DictionaryDefinition> dictionaryDefinitions) {
+        this.dictionaryDefinitions = dictionaryDefinitions;
+    }
+
+    public List<Pattern> getPatterns() {
+        return patterns;
+    }
+
+    public void setPatterns(List<Pattern> patterns) {
+        this.patterns = patterns;
+    }
+
+    public List<String> getIgnoreRegExpList() {
+        return ignoreRegExpList;
+    }
+
+    public void setIgnoreRegExpList(List<String> ignoreRegExpList) {
+        this.ignoreRegExpList = ignoreRegExpList;
+    }
+
+    public List<String> getIncludeRegExpList() {
+        return includeRegExpList;
+    }
+
+    public void setIncludeRegExpList(List<String> includeRegExpList) {
+        this.includeRegExpList = includeRegExpList;
+    }
+
+    public List<String> getImportPaths() {
+        return importPaths;
+    }
+
+    public void setImportPaths(List<String> importPaths) {
+        this.importPaths = importPaths;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Boolean getEnableGlobDot() {
+        return enableGlobDot;
+    }
+
+    public void setEnableGlobDot(Boolean enableGlobDot) {
+        this.enableGlobDot = enableGlobDot;
+    }
+
+    public Boolean getCaseSensitive() {
+        return caseSensitive;
+    }
+
+    public void setCaseSensitive(Boolean caseSensitive) {
+        this.caseSensitive = caseSensitive;
+    }
+
+    public Boolean getAllowCompoundWords() {
+        return allowCompoundWords;
+    }
+
+    public void setAllowCompoundWords(Boolean allowCompoundWords) {
+        this.allowCompoundWords = allowCompoundWords;
+    }
+
+    public List<String> getFlagWords() {
+        return flagWords;
+    }
+
+    public void setFlagWords(List<String> flagWords) {
+        this.flagWords = flagWords;
+    }
+
+    public String getGlobRoot() {
+        return globRoot;
+    }
+
+    public void setGlobRoot(String globRoot) {
+        this.globRoot = globRoot;
+    }
+
+    public List<Override> getOverrides() {
+        return overrides;
+    }
+
+    public void setOverrides(List<Override> overrides) {
+        this.overrides = overrides;
+    }
+
+    // Nested Classes
+
+    /**
+     * Defines a custom dictionary.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class DictionaryDefinition {
+        @JsonProperty("name")
+        private String name;
+
+        @JsonProperty("path")
+        private String path;
+
+        @JsonProperty("description")
+        private String description;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public void setPath(String path) {
+            this.path = path;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+    }
+
+    /**
+     * Defines a pattern for matching text.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Pattern {
+        @JsonProperty("name")
+        private String name;
+
+        @JsonProperty("pattern")
+        private String pattern;
+
+        @JsonProperty("description")
+        private String description;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getPattern() {
+            return pattern;
+        }
+
+        public void setPattern(String pattern) {
+            this.pattern = pattern;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+    }
+
+    /**
+     * Override settings for specific files.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Override {
+        @JsonProperty("filename")
+        private String filename;
+
+        @JsonProperty("language")
+        private String language;
+
+        @JsonProperty("words")
+        private List<String> words;
+
+        @JsonProperty("ignoreWords")
+        private List<String> ignoreWords;
+
+        @JsonProperty("enabled")
+        private Boolean enabled;
+
+        public Override() {
+            this.words = new ArrayList<>();
+            this.ignoreWords = new ArrayList<>();
+        }
+
+        public String getFilename() {
+            return filename;
+        }
+
+        public void setFilename(String filename) {
+            this.filename = filename;
+        }
+
+        public String getLanguage() {
+            return language;
+        }
+
+        public void setLanguage(String language) {
+            this.language = language;
+        }
+
+        public List<String> getWords() {
+            return words;
+        }
+
+        public void setWords(List<String> words) {
+            this.words = words;
+        }
+
+        public List<String> getIgnoreWords() {
+            return ignoreWords;
+        }
+
+        public void setIgnoreWords(List<String> ignoreWords) {
+            this.ignoreWords = ignoreWords;
+        }
+
+        public Boolean getEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(Boolean enabled) {
+            this.enabled = enabled;
+        }
+    }
+}

--- a/src/main/java/com/github/tizuno/maven/spellcheck/config/CSpellConfigLoader.java
+++ b/src/main/java/com/github/tizuno/maven/spellcheck/config/CSpellConfigLoader.java
@@ -1,0 +1,279 @@
+package com.github.tizuno.maven.spellcheck.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.maven.plugin.logging.Log;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Loader for CSpell configuration files.
+ * Supports loading cspell.json or .cspell.json files.
+ *
+ * @author T. Izuno
+ * @since 1.0.0
+ */
+public class CSpellConfigLoader {
+
+    private static final String[] CONFIG_FILE_NAMES = {
+        "cspell.json",
+        ".cspell.json",
+        "cSpell.json",
+        ".cSpell.json"
+    };
+
+    private final ObjectMapper objectMapper;
+    private final Log log;
+    private final Set<String> loadedFiles;
+
+    /**
+     * Creates a new CSpell configuration loader.
+     *
+     * @param log Maven logger
+     */
+    public CSpellConfigLoader(Log log) {
+        this.objectMapper = new ObjectMapper();
+        this.log = log;
+        this.loadedFiles = new HashSet<>();
+    }
+
+    /**
+     * Finds and loads a CSpell configuration file from the given directory.
+     *
+     * @param baseDirectory the directory to search for configuration files
+     * @return the loaded configuration, or null if no configuration file found
+     * @throws IOException if an error occurs reading the configuration file
+     */
+    public CSpellConfig loadConfig(File baseDirectory) throws IOException {
+        File configFile = findConfigFile(baseDirectory);
+
+        if (configFile == null) {
+            log.debug("No CSpell configuration file found in: " + baseDirectory.getAbsolutePath());
+            return null;
+        }
+
+        log.info("Loading CSpell configuration from: " + configFile.getAbsolutePath());
+        return loadConfigFile(configFile, baseDirectory);
+    }
+
+    /**
+     * Loads a specific CSpell configuration file.
+     *
+     * @param configFile the configuration file to load
+     * @return the loaded configuration
+     * @throws IOException if an error occurs reading the configuration file
+     */
+    public CSpellConfig loadConfig(File configFile) throws IOException {
+        if (configFile == null || !configFile.exists()) {
+            throw new IOException("Configuration file does not exist: " + configFile);
+        }
+
+        File baseDirectory = configFile.getParentFile();
+        return loadConfigFile(configFile, baseDirectory);
+    }
+
+    /**
+     * Finds a CSpell configuration file in the given directory.
+     *
+     * @param directory the directory to search
+     * @return the configuration file, or null if not found
+     */
+    private File findConfigFile(File directory) {
+        if (directory == null || !directory.exists() || !directory.isDirectory()) {
+            return null;
+        }
+
+        for (String fileName : CONFIG_FILE_NAMES) {
+            File configFile = new File(directory, fileName);
+            if (configFile.exists() && configFile.isFile()) {
+                return configFile;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Loads and parses a CSpell configuration file.
+     *
+     * @param configFile the file to load
+     * @param baseDirectory the base directory for resolving relative paths
+     * @return the loaded configuration
+     * @throws IOException if an error occurs reading or parsing the file
+     */
+    private CSpellConfig loadConfigFile(File configFile, File baseDirectory) throws IOException {
+        String absolutePath = configFile.getAbsolutePath();
+
+        // Prevent circular imports
+        if (loadedFiles.contains(absolutePath)) {
+            log.warn("Circular import detected, skipping: " + absolutePath);
+            return new CSpellConfig();
+        }
+
+        loadedFiles.add(absolutePath);
+
+        // Parse the JSON file
+        CSpellConfig config = objectMapper.readValue(configFile, CSpellConfig.class);
+
+        // Process imports
+        if (config.getImportPaths() != null && !config.getImportPaths().isEmpty()) {
+            config = processImports(config, baseDirectory);
+        }
+
+        return config;
+    }
+
+    /**
+     * Processes import statements in the configuration.
+     *
+     * @param config the configuration with imports
+     * @param baseDirectory the base directory for resolving import paths
+     * @return the merged configuration
+     * @throws IOException if an error occurs loading imported files
+     */
+    private CSpellConfig processImports(CSpellConfig config, File baseDirectory) throws IOException {
+        CSpellConfig mergedConfig = new CSpellConfig();
+
+        // Load and merge imported configurations
+        for (String importPath : config.getImportPaths()) {
+            File importFile = resolveImportPath(importPath, baseDirectory);
+
+            if (importFile != null && importFile.exists()) {
+                log.debug("Importing configuration from: " + importFile.getAbsolutePath());
+                CSpellConfig importedConfig = loadConfigFile(importFile, importFile.getParentFile());
+                mergedConfig = mergeConfigs(mergedConfig, importedConfig);
+            } else {
+                log.warn("Import file not found: " + importPath);
+            }
+        }
+
+        // Merge current configuration on top of imported configurations
+        mergedConfig = mergeConfigs(mergedConfig, config);
+
+        return mergedConfig;
+    }
+
+    /**
+     * Resolves an import path to a file.
+     *
+     * @param importPath the import path (can be relative or absolute)
+     * @param baseDirectory the base directory for relative paths
+     * @return the resolved file, or null if it cannot be resolved
+     */
+    private File resolveImportPath(String importPath, File baseDirectory) {
+        File importFile = new File(importPath);
+
+        // If absolute path and exists
+        if (importFile.isAbsolute()) {
+            return importFile;
+        }
+
+        // Try relative to base directory
+        importFile = new File(baseDirectory, importPath);
+        if (importFile.exists()) {
+            return importFile;
+        }
+
+        return null;
+    }
+
+    /**
+     * Merges two configurations, with the override configuration taking precedence.
+     *
+     * @param base the base configuration
+     * @param override the overriding configuration
+     * @return the merged configuration
+     */
+    private CSpellConfig mergeConfigs(CSpellConfig base, CSpellConfig override) {
+        CSpellConfig merged = new CSpellConfig();
+
+        // Simple properties (override takes precedence if not null)
+        merged.setVersion(override.getVersion() != null ? override.getVersion() : base.getVersion());
+        merged.setLanguage(override.getLanguage() != null ? override.getLanguage() : base.getLanguage());
+        merged.setEnabled(override.getEnabled() != null ? override.getEnabled() : base.getEnabled());
+        merged.setEnableGlobDot(override.getEnableGlobDot() != null ? override.getEnableGlobDot() : base.getEnableGlobDot());
+        merged.setCaseSensitive(override.getCaseSensitive() != null ? override.getCaseSensitive() : base.getCaseSensitive());
+        merged.setAllowCompoundWords(override.getAllowCompoundWords() != null ? override.getAllowCompoundWords() : base.getAllowCompoundWords());
+        merged.setGlobRoot(override.getGlobRoot() != null ? override.getGlobRoot() : base.getGlobRoot());
+
+        // List properties (merge both lists)
+        merged.setWords(mergeLists(base.getWords(), override.getWords()));
+        merged.setIgnoreWords(mergeLists(base.getIgnoreWords(), override.getIgnoreWords()));
+        merged.setIgnorePaths(mergeLists(base.getIgnorePaths(), override.getIgnorePaths()));
+        merged.setFiles(mergeLists(base.getFiles(), override.getFiles()));
+        merged.setDictionaries(mergeLists(base.getDictionaries(), override.getDictionaries()));
+        merged.setIgnoreRegExpList(mergeLists(base.getIgnoreRegExpList(), override.getIgnoreRegExpList()));
+        merged.setIncludeRegExpList(mergeLists(base.getIncludeRegExpList(), override.getIncludeRegExpList()));
+        merged.setFlagWords(mergeLists(base.getFlagWords(), override.getFlagWords()));
+
+        // Don't merge import paths (already processed)
+        merged.setImportPaths(new ArrayList<>());
+
+        // Merge complex objects
+        merged.setDictionaryDefinitions(mergeLists(base.getDictionaryDefinitions(), override.getDictionaryDefinitions()));
+        merged.setPatterns(mergeLists(base.getPatterns(), override.getPatterns()));
+        merged.setOverrides(mergeLists(base.getOverrides(), override.getOverrides()));
+
+        return merged;
+    }
+
+    /**
+     * Merges two lists, combining their elements.
+     *
+     * @param list1 the first list
+     * @param list2 the second list
+     * @param <T> the type of list elements
+     * @return a new list containing all elements from both lists
+     */
+    private <T> List<T> mergeLists(List<T> list1, List<T> list2) {
+        List<T> merged = new ArrayList<>();
+
+        if (list1 != null) {
+            merged.addAll(list1);
+        }
+
+        if (list2 != null) {
+            merged.addAll(list2);
+        }
+
+        return merged;
+    }
+
+    /**
+     * Converts a CSpell configuration to a SpellCheckConfiguration.
+     *
+     * @param cspellConfig the CSpell configuration
+     * @return the SpellCheckConfiguration
+     */
+    public SpellCheckConfiguration toSpellCheckConfiguration(CSpellConfig cspellConfig) {
+        SpellCheckConfiguration config = new SpellCheckConfiguration();
+
+        if (cspellConfig == null) {
+            return config;
+        }
+
+        // Set language
+        if (cspellConfig.getLanguage() != null) {
+            // CSpell can have multiple languages separated by comma (e.g., "en,nl")
+            // For now, use the first one
+            String language = cspellConfig.getLanguage().split(",")[0].trim();
+            config.setLanguage(language);
+        }
+
+        // Merge words and ignoreWords
+        List<String> allIgnoreWords = new ArrayList<>();
+        if (cspellConfig.getWords() != null) {
+            allIgnoreWords.addAll(cspellConfig.getWords());
+        }
+        if (cspellConfig.getIgnoreWords() != null) {
+            allIgnoreWords.addAll(cspellConfig.getIgnoreWords());
+        }
+        config.setIgnoreWords(allIgnoreWords);
+
+        return config;
+    }
+}

--- a/src/test/java/com/github/tizuno/maven/spellcheck/config/CSpellConfigLoaderTest.java
+++ b/src/test/java/com/github/tizuno/maven/spellcheck/config/CSpellConfigLoaderTest.java
@@ -1,0 +1,186 @@
+package com.github.tizuno.maven.spellcheck.config;
+
+import org.apache.maven.plugin.logging.Log;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test for CSpellConfigLoader.
+ *
+ * @author T. Izuno
+ * @since 1.0.0
+ */
+public class CSpellConfigLoaderTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private Log log;
+    private CSpellConfigLoader loader;
+
+    @Before
+    public void setUp() {
+        log = mock(Log.class);
+        loader = new CSpellConfigLoader(log);
+    }
+
+    @Test
+    public void testLoadBasicConfig() throws IOException {
+        // Create a basic cspell.json file
+        String configJson = "{\n" +
+                "  \"version\": \"0.2\",\n" +
+                "  \"language\": \"en-US\",\n" +
+                "  \"words\": [\"testword\", \"anotherword\"],\n" +
+                "  \"ignoreWords\": [\"ignoreword\"]\n" +
+                "}";
+
+        File configFile = tempFolder.newFile("cspell.json");
+        Files.write(configFile.toPath(), configJson.getBytes(StandardCharsets.UTF_8));
+
+        CSpellConfig config = loader.loadConfig(configFile);
+
+        assertNotNull(config);
+        assertEquals("0.2", config.getVersion());
+        assertEquals("en-US", config.getLanguage());
+        assertEquals(2, config.getWords().size());
+        assertTrue(config.getWords().contains("testword"));
+        assertTrue(config.getWords().contains("anotherword"));
+        assertEquals(1, config.getIgnoreWords().size());
+        assertTrue(config.getIgnoreWords().contains("ignoreword"));
+    }
+
+    @Test
+    public void testLoadConfigWithIgnorePaths() throws IOException {
+        String configJson = "{\n" +
+                "  \"version\": \"0.2\",\n" +
+                "  \"ignorePaths\": [\"node_modules/**\", \"*.min.js\"]\n" +
+                "}";
+
+        File configFile = tempFolder.newFile("cspell.json");
+        Files.write(configFile.toPath(), configJson.getBytes(StandardCharsets.UTF_8));
+
+        CSpellConfig config = loader.loadConfig(configFile);
+
+        assertNotNull(config);
+        assertEquals(2, config.getIgnorePaths().size());
+        assertTrue(config.getIgnorePaths().contains("node_modules/**"));
+        assertTrue(config.getIgnorePaths().contains("*.min.js"));
+    }
+
+    @Test
+    public void testLoadConfigWithDictionaries() throws IOException {
+        String configJson = "{\n" +
+                "  \"version\": \"0.2\",\n" +
+                "  \"dictionaries\": [\"custom\", \"companies\"],\n" +
+                "  \"dictionaryDefinitions\": [\n" +
+                "    {\n" +
+                "      \"name\": \"custom\",\n" +
+                "      \"path\": \"./custom-dictionary.txt\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+
+        File configFile = tempFolder.newFile("cspell.json");
+        Files.write(configFile.toPath(), configJson.getBytes(StandardCharsets.UTF_8));
+
+        CSpellConfig config = loader.loadConfig(configFile);
+
+        assertNotNull(config);
+        assertEquals(2, config.getDictionaries().size());
+        assertTrue(config.getDictionaries().contains("custom"));
+        assertTrue(config.getDictionaries().contains("companies"));
+        assertEquals(1, config.getDictionaryDefinitions().size());
+        assertEquals("custom", config.getDictionaryDefinitions().get(0).getName());
+        assertEquals("./custom-dictionary.txt", config.getDictionaryDefinitions().get(0).getPath());
+    }
+
+    @Test
+    public void testFindConfigInDirectory() throws IOException {
+        String configJson = "{\n" +
+                "  \"version\": \"0.2\",\n" +
+                "  \"language\": \"en\"\n" +
+                "}";
+
+        File dir = tempFolder.newFolder();
+        File configFile = new File(dir, "cspell.json");
+        Files.write(configFile.toPath(), configJson.getBytes(StandardCharsets.UTF_8));
+
+        CSpellConfig config = loader.loadConfig(dir);
+
+        assertNotNull(config);
+        assertEquals("0.2", config.getVersion());
+        assertEquals("en", config.getLanguage());
+    }
+
+    @Test
+    public void testFindConfigWithDotPrefix() throws IOException {
+        String configJson = "{\n" +
+                "  \"version\": \"0.2\",\n" +
+                "  \"language\": \"en\"\n" +
+                "}";
+
+        File dir = tempFolder.newFolder();
+        File configFile = new File(dir, ".cspell.json");
+        Files.write(configFile.toPath(), configJson.getBytes(StandardCharsets.UTF_8));
+
+        CSpellConfig config = loader.loadConfig(dir);
+
+        assertNotNull(config);
+        assertEquals("en", config.getLanguage());
+    }
+
+    @Test
+    public void testNoConfigFound() throws IOException {
+        File dir = tempFolder.newFolder();
+
+        CSpellConfig config = loader.loadConfig(dir);
+
+        assertNull(config);
+    }
+
+    @Test
+    public void testToSpellCheckConfiguration() {
+        CSpellConfig cspellConfig = new CSpellConfig();
+        cspellConfig.setLanguage("en-US");
+        cspellConfig.getWords().add("customword");
+        cspellConfig.getIgnoreWords().add("ignoreword");
+
+        SpellCheckConfiguration config = loader.toSpellCheckConfiguration(cspellConfig);
+
+        assertNotNull(config);
+        assertEquals("en-US", config.getLanguage());
+        assertEquals(2, config.getIgnoreWords().size());
+        assertTrue(config.getIgnoreWords().contains("customword"));
+        assertTrue(config.getIgnoreWords().contains("ignoreword"));
+    }
+
+    @Test
+    public void testToSpellCheckConfigurationWithMultipleLanguages() {
+        CSpellConfig cspellConfig = new CSpellConfig();
+        cspellConfig.setLanguage("en,nl,de");
+
+        SpellCheckConfiguration config = loader.toSpellCheckConfiguration(cspellConfig);
+
+        assertNotNull(config);
+        // Should use the first language
+        assertEquals("en", config.getLanguage());
+    }
+
+    @Test
+    public void testToSpellCheckConfigurationWithNull() {
+        SpellCheckConfiguration config = loader.toSpellCheckConfiguration(null);
+
+        assertNotNull(config);
+        // Should return default configuration
+    }
+}


### PR DESCRIPTION
Add comprehensive support for CSpell configuration files (cspell.json, .cspell.json) to the Maven plugin, enabling compatibility with the popular CSpell spell checker.

Changes:
- Add Jackson dependency for JSON processing
- Create CSpellConfig model class with support for all major CSpell properties (version, language, words, ignoreWords, ignorePaths, files, dictionaries, etc.)
- Implement CSpellConfigLoader with features:
  - Auto-detection of cspell.json files in project root
  - Support for importing other configuration files
  - Configuration merging with proper priority
  - Circular import prevention
- Update SpellCheckMojo to integrate CSpell configuration:
  - Add useCSpellConfig parameter (default: true)
  - Add cspellConfigFile parameter for custom config paths
  - Merge CSpell settings with Maven plugin parameters
  - Maven parameters take precedence over CSpell config
- Add comprehensive unit tests for CSpellConfigLoader
- Add Mockito dependency for testing
- Create cspell.json.example as reference
- Update README.md with:
  - CSpell configuration documentation
  - Usage examples
  - Supported features list
  - Configuration priority explanation

This allows users to use the same cspell.json configuration file for both IDE spell checking and Maven build integration, improving developer experience and reducing configuration duplication.