### PR TITLE
Add GitHub Actions for build and test

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1,0 +1,61 @@
+name: Maven Build and Test
+
+on:
+  push:
+    branches: [ main, develop, 'feature/**', 'claude/**' ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        java: [ '8', '11', '17' ]
+      fail-fast: false
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v4
+      with:
+        java-version: ${{ matrix.java }}
+        distribution: 'temurin'
+        cache: 'maven'
+
+    - name: Display Maven version
+      run: mvn -version
+
+    - name: Build with Maven
+      run: mvn -B clean compile --file pom.xml
+
+    - name: Run tests
+      run: mvn -B test --file pom.xml
+
+    - name: Run integration tests
+      run: mvn -B verify --file pom.xml
+
+    - name: Package
+      run: mvn -B package -DskipTests --file pom.xml
+
+    - name: Upload build artifacts
+      if: matrix.java == '11'
+      uses: actions/upload-artifact@v4
+      with:
+        name: maven-plugin-package
+        path: target/*.jar
+        retention-days: 7
+
+    - name: Upload test results
+      if: always() && matrix.java == '11'
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results
+        path: |
+          target/surefire-reports/
+          target/failsafe-reports/
+        retention-days: 7

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -33,14 +33,8 @@ jobs:
     - name: Build with Maven
       run: mvn -B clean compile --file pom.xml
 
-    - name: Run tests
-      run: mvn -B test --file pom.xml
-
     - name: Run integration tests
       run: mvn -B verify --file pom.xml
-
-    - name: Package
-      run: mvn -B package -DskipTests --file pom.xml
 
     - name: Upload build artifacts
       if: matrix.java == '11'

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -33,15 +33,8 @@ jobs:
     - name: Build with Maven
       run: mvn -B clean compile --file pom.xml
 
-    - name: Run tests
-      run: mvn -B test --file pom.xml
-
     - name: Run integration tests
       run: mvn -B verify --file pom.xml
-
-    - name: Package
-      run: mvn -B package -DskipTests --file pom.xml
-
     - name: Upload build artifacts
       if: matrix.java == '11'
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Add Maven build and test workflow with the following features:
- Multi-version Java testing (8, 11, 17)
- Build, test, and package steps
- Integration tests with maven-invoker-plugin
- Dependency caching for faster builds
- Upload build artifacts and test results

The workflow triggers on push to main, develop, feature/**, and claude/** branches, as well as pull requests to main and develop.