### PR TITLE
Enable spell check results in CI tool reports

### DIFF
--- a/src/main/java/com/github/tizuno/maven/spellcheck/report/CheckstyleXmlReportGenerator.java
+++ b/src/main/java/com/github/tizuno/maven/spellcheck/report/CheckstyleXmlReportGenerator.java
@@ -1,0 +1,104 @@
+package com.github.tizuno.maven.spellcheck.report;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Generates Checkstyle XML format reports for spell check results.
+ * This format is supported by Jenkins Warnings Next Generation plugin,
+ * SonarQube, and other code quality tools.
+ *
+ * @author T. Izuno
+ * @since 1.0.0
+ */
+public class CheckstyleXmlReportGenerator {
+
+    private static final String XML_HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+    private static final String CHECKSTYLE_VERSION = "10.0";
+
+    /**
+     * Generates a Checkstyle XML report from spell check results.
+     *
+     * @param report     the spell check report
+     * @param outputFile the output XML file
+     * @throws IOException if writing fails
+     */
+    public void generateReport(SpellCheckReport report, File outputFile) throws IOException {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(outputFile))) {
+            writer.write(XML_HEADER);
+            writer.newLine();
+
+            // Write checkstyle opening tag
+            writer.write(String.format("<checkstyle version=\"%s\">", CHECKSTYLE_VERSION));
+            writer.newLine();
+
+            // Write errors grouped by file
+            Map<File, List<SpellError>> errorsByFile = report.getErrorsByFile();
+
+            for (Map.Entry<File, List<SpellError>> entry : errorsByFile.entrySet()) {
+                File file = entry.getKey();
+                List<SpellError> fileErrors = entry.getValue();
+
+                // Write file opening tag with absolute path
+                writer.write(String.format("  <file name=\"%s\">", escapeXml(file.getAbsolutePath())));
+                writer.newLine();
+
+                // Write each error as an error element
+                for (SpellError error : fileErrors) {
+                    // Build error message
+                    StringBuilder message = new StringBuilder();
+                    message.append(String.format("Spelling error: '%s' - %s",
+                        error.getWord(),
+                        error.getMessage()
+                    ));
+
+                    if (error.getSuggestions() != null && !error.getSuggestions().isEmpty()) {
+                        message.append(" [Suggestions: ");
+                        int suggestionCount = Math.min(3, error.getSuggestions().size());
+                        message.append(String.join(", ",
+                            error.getSuggestions().subList(0, suggestionCount)));
+                        message.append("]");
+                    }
+
+                    // Write error element
+                    writer.write(String.format(
+                        "    <error line=\"%d\" column=\"%d\" severity=\"error\" message=\"%s\" source=\"SpellCheck\"/>",
+                        error.getLine(),
+                        error.getColumn(),
+                        escapeXml(message.toString())
+                    ));
+                    writer.newLine();
+                }
+
+                // Write file closing tag
+                writer.write("  </file>");
+                writer.newLine();
+            }
+
+            // Close checkstyle
+            writer.write("</checkstyle>");
+            writer.newLine();
+        }
+    }
+
+    /**
+     * Escapes special XML characters.
+     *
+     * @param text the text to escape
+     * @return the escaped text
+     */
+    private String escapeXml(String text) {
+        if (text == null) {
+            return "";
+        }
+        return text.replace("&", "&amp;")
+                   .replace("<", "&lt;")
+                   .replace(">", "&gt;")
+                   .replace("\"", "&quot;")
+                   .replace("'", "&apos;");
+    }
+}

--- a/src/main/java/com/github/tizuno/maven/spellcheck/report/JUnitXmlReportGenerator.java
+++ b/src/main/java/com/github/tizuno/maven/spellcheck/report/JUnitXmlReportGenerator.java
@@ -1,0 +1,131 @@
+package com.github.tizuno.maven.spellcheck.report;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Generates JUnit XML format reports for spell check results.
+ * This format is widely supported by CI/CD tools like Jenkins, GitLab CI, GitHub Actions, etc.
+ *
+ * @author T. Izuno
+ * @since 1.0.0
+ */
+public class JUnitXmlReportGenerator {
+
+    private static final String XML_HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+
+    /**
+     * Generates a JUnit XML report from spell check results.
+     *
+     * @param report     the spell check report
+     * @param outputFile the output XML file
+     * @throws IOException if writing fails
+     */
+    public void generateReport(SpellCheckReport report, File outputFile) throws IOException {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(outputFile))) {
+            writer.write(XML_HEADER);
+            writer.newLine();
+
+            // Calculate test suite metrics
+            int totalTests = report.getFilesChecked();
+            int failures = report.getErrorsByFile().size(); // Files with errors
+            int errors = 0; // We don't distinguish between errors and failures for spell check
+            double totalTime = 0.0; // Time is not tracked in our implementation
+
+            // Write testsuite opening tag
+            writer.write(String.format(
+                "<testsuite name=\"SpellCheck\" tests=\"%d\" failures=\"%d\" errors=\"%d\" time=\"%.3f\" timestamp=\"%s\">",
+                totalTests, failures, errors, totalTime, Instant.now().toString()
+            ));
+            writer.newLine();
+
+            // Write testcases for each file checked
+            Map<File, List<SpellError>> errorsByFile = report.getErrorsByFile();
+
+            // First, write test cases for files with errors
+            for (Map.Entry<File, List<SpellError>> entry : errorsByFile.entrySet()) {
+                File file = entry.getKey();
+                List<SpellError> fileErrors = entry.getValue();
+
+                writer.write(String.format(
+                    "  <testcase name=\"%s\" classname=\"SpellCheck\" time=\"0.0\">",
+                    escapeXml(file.getPath())
+                ));
+                writer.newLine();
+
+                // Create failure message with all errors for this file
+                StringBuilder failureMessage = new StringBuilder();
+                failureMessage.append(String.format("Found %d spelling error(s) in %s",
+                    fileErrors.size(), file.getPath()));
+
+                StringBuilder failureDetail = new StringBuilder();
+                for (SpellError error : fileErrors) {
+                    failureDetail.append(String.format("%s:%d:%d: '%s' - %s",
+                        file.getPath(),
+                        error.getLine(),
+                        error.getColumn(),
+                        error.getWord(),
+                        error.getMessage()
+                    ));
+
+                    if (error.getSuggestions() != null && !error.getSuggestions().isEmpty()) {
+                        failureDetail.append(" [Suggestions: ");
+                        int suggestionCount = Math.min(3, error.getSuggestions().size());
+                        failureDetail.append(String.join(", ",
+                            error.getSuggestions().subList(0, suggestionCount)));
+                        failureDetail.append("]");
+                    }
+                    failureDetail.append("\n");
+                }
+
+                writer.write(String.format(
+                    "    <failure message=\"%s\" type=\"SpellingError\">%s</failure>",
+                    escapeXml(failureMessage.toString()),
+                    escapeXml(failureDetail.toString())
+                ));
+                writer.newLine();
+
+                writer.write("  </testcase>");
+                writer.newLine();
+            }
+
+            // Then, write test cases for files without errors (passed tests)
+            // Note: We don't track individual files in the current implementation,
+            // so we'll just add a summary if there are files that passed
+            int filesWithoutErrors = totalTests - failures;
+            if (filesWithoutErrors > 0) {
+                writer.write(String.format(
+                    "  <testcase name=\"%d files passed spell check\" classname=\"SpellCheck\" time=\"0.0\"/>",
+                    filesWithoutErrors
+                ));
+                writer.newLine();
+            }
+
+            // Close testsuite
+            writer.write("</testsuite>");
+            writer.newLine();
+        }
+    }
+
+    /**
+     * Escapes special XML characters.
+     *
+     * @param text the text to escape
+     * @return the escaped text
+     */
+    private String escapeXml(String text) {
+        if (text == null) {
+            return "";
+        }
+        return text.replace("&", "&amp;")
+                   .replace("<", "&lt;")
+                   .replace(">", "&gt;")
+                   .replace("\"", "&quot;")
+                   .replace("'", "&apos;");
+    }
+}

--- a/src/test/java/com/github/tizuno/maven/spellcheck/report/CheckstyleXmlReportGeneratorTest.java
+++ b/src/test/java/com/github/tizuno/maven/spellcheck/report/CheckstyleXmlReportGeneratorTest.java
@@ -1,0 +1,236 @@
+package com.github.tizuno.maven.spellcheck.report;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link CheckstyleXmlReportGenerator}.
+ *
+ * @author T. Izuno
+ * @since 1.0.0
+ */
+public class CheckstyleXmlReportGeneratorTest {
+
+    private CheckstyleXmlReportGenerator generator;
+    private Path tempDir;
+    private File outputFile;
+
+    @Before
+    public void setUp() throws IOException {
+        generator = new CheckstyleXmlReportGenerator();
+        tempDir = Files.createTempDirectory("checkstyle-report-test");
+        outputFile = new File(tempDir.toFile(), "checkstyle-report.xml");
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        // Clean up temp directory
+        if (outputFile.exists()) {
+            outputFile.delete();
+        }
+        Files.deleteIfExists(tempDir);
+    }
+
+    @Test
+    public void testGenerateEmptyReport() throws IOException {
+        // Given
+        SpellCheckReport report = new SpellCheckReport();
+        report.incrementFilesChecked();
+
+        // When
+        generator.generateReport(report, outputFile);
+
+        // Then
+        assertTrue("Output file should exist", outputFile.exists());
+
+        String content = new String(Files.readAllBytes(outputFile.toPath()));
+        assertTrue("Should contain XML header", content.contains("<?xml version=\"1.0\""));
+        assertTrue("Should contain checkstyle element", content.contains("<checkstyle"));
+        assertTrue("Should contain version", content.contains("version="));
+        assertTrue("Should contain closing checkstyle", content.contains("</checkstyle>"));
+    }
+
+    @Test
+    public void testGenerateReportWithErrors() throws IOException {
+        // Given
+        SpellCheckReport report = new SpellCheckReport();
+        report.incrementFilesChecked();
+
+        File file1 = new File("/path/to/TestFile.java");
+        File file2 = new File("/path/to/AnotherFile.java");
+
+        SpellError error1 = new SpellError(
+            file1, 10, 5, "teh",
+            "Possible spelling mistake found",
+            Arrays.asList("the", "tea", "ten")
+        );
+
+        SpellError error2 = new SpellError(
+            file1, 15, 10, "recieve",
+            "Possible spelling mistake found",
+            Arrays.asList("receive")
+        );
+
+        SpellError error3 = new SpellError(
+            file2, 20, 3, "occurence",
+            "Possible spelling mistake found",
+            Arrays.asList("occurrence")
+        );
+
+        report.addError(error1);
+        report.addError(error2);
+        report.addError(error3);
+
+        // When
+        generator.generateReport(report, outputFile);
+
+        // Then
+        assertTrue("Output file should exist", outputFile.exists());
+
+        String content = new String(Files.readAllBytes(outputFile.toPath()));
+
+        // Verify XML structure
+        assertTrue("Should contain XML header", content.contains("<?xml version=\"1.0\""));
+        assertTrue("Should contain checkstyle element", content.contains("<checkstyle"));
+
+        // Verify file elements
+        assertTrue("Should contain file element for TestFile.java",
+            content.contains("<file name=\"" + file1.getAbsolutePath()));
+        assertTrue("Should contain file element for AnotherFile.java",
+            content.contains("<file name=\"" + file2.getAbsolutePath()));
+
+        // Verify error elements
+        assertTrue("Should contain error element", content.contains("<error"));
+        assertTrue("Should have line attribute", content.contains("line="));
+        assertTrue("Should have column attribute", content.contains("column="));
+        assertTrue("Should have severity attribute", content.contains("severity=\"error\""));
+        assertTrue("Should have message attribute", content.contains("message="));
+        assertTrue("Should have source attribute", content.contains("source=\"SpellCheck\""));
+
+        // Verify error details
+        assertTrue("Should contain 'teh' error", content.contains("teh"));
+        assertTrue("Should contain 'recieve' error", content.contains("recieve"));
+        assertTrue("Should contain 'occurence' error", content.contains("occurence"));
+
+        // Verify suggestions
+        assertTrue("Should contain suggestions", content.contains("Suggestions:"));
+    }
+
+    @Test
+    public void testXmlEscaping() throws IOException {
+        // Given
+        SpellCheckReport report = new SpellCheckReport();
+        report.incrementFilesChecked();
+
+        File file = new File("/path/with/special<chars>&\"name\"/Test.java");
+        SpellError error = new SpellError(
+            file, 1, 1, "test",
+            "Error with special chars: <>&\"'",
+            Arrays.asList("suggestion")
+        );
+        report.addError(error);
+
+        // When
+        generator.generateReport(report, outputFile);
+
+        // Then
+        assertTrue("Output file should exist", outputFile.exists());
+
+        String content = new String(Files.readAllBytes(outputFile.toPath()));
+
+        // Verify special characters are escaped
+        assertTrue("Should escape <", content.contains("&lt;"));
+        assertTrue("Should escape >", content.contains("&gt;"));
+        assertTrue("Should escape &", content.contains("&amp;"));
+        assertTrue("Should escape \"", content.contains("&quot;"));
+    }
+
+    @Test
+    public void testMultipleErrorsInSameFile() throws IOException {
+        // Given
+        SpellCheckReport report = new SpellCheckReport();
+        report.incrementFilesChecked();
+
+        File file = new File("/path/to/TestFile.java");
+
+        for (int i = 1; i <= 5; i++) {
+            SpellError error = new SpellError(
+                file, i * 10, i, "error" + i,
+                "Error message " + i,
+                Arrays.asList("correction" + i)
+            );
+            report.addError(error);
+        }
+
+        // When
+        generator.generateReport(report, outputFile);
+
+        // Then
+        assertTrue("Output file should exist", outputFile.exists());
+
+        String content = new String(Files.readAllBytes(outputFile.toPath()));
+
+        // Should have one file element with multiple error elements
+        int fileTagCount = countOccurrences(content, "<file");
+        assertEquals("Should have exactly one file element", 1, fileTagCount);
+
+        int errorTagCount = countOccurrences(content, "<error");
+        assertEquals("Should have 5 error elements", 5, errorTagCount);
+
+        // Verify all errors are present
+        for (int i = 1; i <= 5; i++) {
+            assertTrue("Should contain error" + i, content.contains("error" + i));
+            assertTrue("Should contain line " + (i * 10), content.contains("line=\"" + (i * 10) + "\""));
+        }
+    }
+
+    @Test
+    public void testErrorAttributes() throws IOException {
+        // Given
+        SpellCheckReport report = new SpellCheckReport();
+        report.incrementFilesChecked();
+
+        File file = new File("/path/to/TestFile.java");
+        SpellError error = new SpellError(
+            file, 42, 15, "misspeled",
+            "Possible spelling mistake",
+            Arrays.asList("misspelled", "mis-spelled")
+        );
+        report.addError(error);
+
+        // When
+        generator.generateReport(report, outputFile);
+
+        // Then
+        String content = new String(Files.readAllBytes(outputFile.toPath()));
+
+        // Verify error attributes
+        assertTrue("Should have correct line number", content.contains("line=\"42\""));
+        assertTrue("Should have correct column number", content.contains("column=\"15\""));
+        assertTrue("Should have severity='error'", content.contains("severity=\"error\""));
+        assertTrue("Should have source='SpellCheck'", content.contains("source=\"SpellCheck\""));
+        assertTrue("Should contain word in message", content.contains("misspeled"));
+    }
+
+    /**
+     * Helper method to count occurrences of a substring.
+     */
+    private int countOccurrences(String text, String substring) {
+        int count = 0;
+        int index = 0;
+        while ((index = text.indexOf(substring, index)) != -1) {
+            count++;
+            index += substring.length();
+        }
+        return count;
+    }
+}

--- a/src/test/java/com/github/tizuno/maven/spellcheck/report/JUnitXmlReportGeneratorTest.java
+++ b/src/test/java/com/github/tizuno/maven/spellcheck/report/JUnitXmlReportGeneratorTest.java
@@ -1,0 +1,194 @@
+package com.github.tizuno.maven.spellcheck.report;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link JUnitXmlReportGenerator}.
+ *
+ * @author T. Izuno
+ * @since 1.0.0
+ */
+public class JUnitXmlReportGeneratorTest {
+
+    private JUnitXmlReportGenerator generator;
+    private Path tempDir;
+    private File outputFile;
+
+    @Before
+    public void setUp() throws IOException {
+        generator = new JUnitXmlReportGenerator();
+        tempDir = Files.createTempDirectory("junit-report-test");
+        outputFile = new File(tempDir.toFile(), "junit-report.xml");
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        // Clean up temp directory
+        if (outputFile.exists()) {
+            outputFile.delete();
+        }
+        Files.deleteIfExists(tempDir);
+    }
+
+    @Test
+    public void testGenerateEmptyReport() throws IOException {
+        // Given
+        SpellCheckReport report = new SpellCheckReport();
+        report.incrementFilesChecked();
+        report.incrementFilesChecked();
+
+        // When
+        generator.generateReport(report, outputFile);
+
+        // Then
+        assertTrue("Output file should exist", outputFile.exists());
+
+        String content = new String(Files.readAllBytes(outputFile.toPath()));
+        assertTrue("Should contain XML header", content.contains("<?xml version=\"1.0\""));
+        assertTrue("Should contain testsuite element", content.contains("<testsuite"));
+        assertTrue("Should show 2 tests checked", content.contains("tests=\"2\""));
+        assertTrue("Should show 0 failures", content.contains("failures=\"0\""));
+        assertTrue("Should contain closing testsuite", content.contains("</testsuite>"));
+    }
+
+    @Test
+    public void testGenerateReportWithErrors() throws IOException {
+        // Given
+        SpellCheckReport report = new SpellCheckReport();
+        report.incrementFilesChecked();
+        report.incrementFilesChecked();
+
+        File file1 = new File("TestFile.java");
+        File file2 = new File("AnotherFile.java");
+
+        SpellError error1 = new SpellError(
+            file1, 10, 5, "teh",
+            "Possible spelling mistake found",
+            Arrays.asList("the", "tea", "ten")
+        );
+
+        SpellError error2 = new SpellError(
+            file1, 15, 10, "recieve",
+            "Possible spelling mistake found",
+            Arrays.asList("receive")
+        );
+
+        SpellError error3 = new SpellError(
+            file2, 20, 3, "occurence",
+            "Possible spelling mistake found",
+            Arrays.asList("occurrence")
+        );
+
+        report.addError(error1);
+        report.addError(error2);
+        report.addError(error3);
+
+        // When
+        generator.generateReport(report, outputFile);
+
+        // Then
+        assertTrue("Output file should exist", outputFile.exists());
+
+        String content = new String(Files.readAllBytes(outputFile.toPath()));
+
+        // Verify XML structure
+        assertTrue("Should contain XML header", content.contains("<?xml version=\"1.0\""));
+        assertTrue("Should contain testsuite element", content.contains("<testsuite"));
+        assertTrue("Should show 2 tests", content.contains("tests=\"2\""));
+        assertTrue("Should show 2 failures", content.contains("failures=\"2\""));
+
+        // Verify test cases
+        assertTrue("Should contain TestFile.java test case", content.contains("TestFile.java"));
+        assertTrue("Should contain AnotherFile.java test case", content.contains("AnotherFile.java"));
+
+        // Verify error details
+        assertTrue("Should contain 'teh' error", content.contains("teh"));
+        assertTrue("Should contain 'recieve' error", content.contains("recieve"));
+        assertTrue("Should contain 'occurence' error", content.contains("occurence"));
+
+        // Verify suggestions
+        assertTrue("Should contain suggestions", content.contains("Suggestions:"));
+
+        // Verify failure elements
+        assertTrue("Should contain failure elements", content.contains("<failure"));
+        assertTrue("Should have SpellingError type", content.contains("type=\"SpellingError\""));
+    }
+
+    @Test
+    public void testXmlEscaping() throws IOException {
+        // Given
+        SpellCheckReport report = new SpellCheckReport();
+        report.incrementFilesChecked();
+
+        File file = new File("Test<File>&\"Name\".java");
+        SpellError error = new SpellError(
+            file, 1, 1, "test",
+            "Error with special chars: <>&\"'",
+            Arrays.asList("suggestion")
+        );
+        report.addError(error);
+
+        // When
+        generator.generateReport(report, outputFile);
+
+        // Then
+        assertTrue("Output file should exist", outputFile.exists());
+
+        String content = new String(Files.readAllBytes(outputFile.toPath()));
+
+        // Verify special characters are escaped
+        assertTrue("Should escape <", content.contains("&lt;"));
+        assertTrue("Should escape >", content.contains("&gt;"));
+        assertTrue("Should escape &", content.contains("&amp;"));
+        assertTrue("Should escape \"", content.contains("&quot;"));
+
+        // Should still be valid XML (no raw special characters in text)
+        assertFalse("Should not contain raw < in attribute values",
+            content.matches(".*name=\"[^\"]*<[^\"]*\".*"));
+    }
+
+    @Test
+    public void testGenerateReportWithMultipleErrorsInSameFile() throws IOException {
+        // Given
+        SpellCheckReport report = new SpellCheckReport();
+        report.incrementFilesChecked();
+
+        File file = new File("TestFile.java");
+
+        for (int i = 1; i <= 5; i++) {
+            SpellError error = new SpellError(
+                file, i * 10, i, "error" + i,
+                "Error message " + i,
+                Arrays.asList("correction" + i)
+            );
+            report.addError(error);
+        }
+
+        // When
+        generator.generateReport(report, outputFile);
+
+        // Then
+        assertTrue("Output file should exist", outputFile.exists());
+
+        String content = new String(Files.readAllBytes(outputFile.toPath()));
+
+        // Should have all errors in one test case for the file
+        assertTrue("Should show 5 errors", content.contains("Found 5 spelling error(s)"));
+
+        // Verify all errors are present
+        for (int i = 1; i <= 5; i++) {
+            assertTrue("Should contain error" + i, content.contains("error" + i));
+        }
+    }
+}


### PR DESCRIPTION
…ports

Implement support for generating CI/CD-friendly report formats to enable integration with Jenkins, GitLab CI, GitHub Actions, and other CI/CD platforms.

Changes:
- Add JUnitXmlReportGenerator for JUnit XML format reports
- Add CheckstyleXmlReportGenerator for Checkstyle XML format reports
- Add generateJUnitReport and generateCheckstyleReport configuration parameters to SpellCheckMojo
- Implement comprehensive unit tests for both report generators
- Update README.md with detailed CI/CD integration examples for:
  * Jenkins with JUnit plugin
  * Jenkins with Warnings Next Generation plugin
  * GitHub Actions
  * GitLab CI

The JUnit XML format is supported by most CI/CD tools and provides test result integration. The Checkstyle XML format is supported by code quality tools like SonarQube and Jenkins Warnings NG plugin.

Report files generated:
- target/spellcheck/spellcheck-junit.xml (when generateJUnitReport=true)
- target/spellcheck/spellcheck-checkstyle.xml (when generateCheckstyleReport=true)

Both formats are disabled by default to maintain backward compatibility.