### PR TITLE
Reorganize Java package hierarchy and Maven group

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ spellcheck-maven-plugin/
 ├── src/
 │   ├── main/
 │   │   ├── java/                   # Java source code
-│   │   │   └── com/yourorg/maven/spellcheck/
+│   │   │   └── io/nncdevel/maven/spellcheck/
 │   │   │       ├── SpellCheckMojo.java          # Main Mojo class
 │   │   │       ├── SpellChecker.java            # Core spell-check logic
 │   │   │       ├── config/                      # Configuration classes
@@ -84,7 +84,7 @@ spellcheck-maven-plugin/
 │   │               └── plugin.xml               # Plugin descriptor (if not using annotations)
 │   └── test/
 │       ├── java/                   # Test source code
-│       │   └── com/yourorg/maven/spellcheck/
+│       │   └── io/nncdevel/maven/spellcheck/
 │       │       ├── SpellCheckMojoTest.java
 │       │       └── integration/                 # Integration tests
 │       └── resources/
@@ -151,7 +151,7 @@ mvn clean install
 
 # Use in a test project
 cd /path/to/test-project
-mvn com.yourorg:spellcheck-maven-plugin:1.0-SNAPSHOT:check
+mvn io.nncdevel.maven:spellcheck-maven-plugin:1.0-SNAPSHOT:check
 ```
 
 ---
@@ -258,7 +258,7 @@ public class SpellCheckMojo extends AbstractMojo {
 - **Classes**: PascalCase (e.g., `SpellCheckMojo`, `DictionaryManager`)
 - **Methods**: camelCase (e.g., `checkSpelling()`, `loadDictionary()`)
 - **Constants**: UPPER_SNAKE_CASE (e.g., `DEFAULT_ENCODING`)
-- **Packages**: lowercase (e.g., `com.yourorg.maven.spellcheck`)
+- **Packages**: lowercase (e.g., `io.nncdevel.maven.spellcheck`)
 
 ### Documentation
 
@@ -338,7 +338,7 @@ Use Maven Invoker Plugin for integration tests:
 ```
 src/test/
 ├── java/
-│   └── com/yourorg/maven/spellcheck/
+│   └── io/nncdevel/maven/spellcheck/
 │       ├── SpellCheckMojoTest.java
 │       ├── DictionaryManagerTest.java
 │       └── integration/

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add the plugin to your `pom.xml`:
 <build>
     <plugins>
         <plugin>
-            <groupId>com.github.tizuno</groupId>
+            <groupId>io.nncdevel.maven</groupId>
             <artifactId>spellcheck-maven-plugin</artifactId>
             <version>1.0.0-SNAPSHOT</version>
             <executions>
@@ -82,7 +82,7 @@ You can configure the plugin in your `pom.xml`:
 
 ```xml
 <plugin>
-    <groupId>com.github.tizuno</groupId>
+    <groupId>io.nncdevel.maven</groupId>
     <artifactId>spellcheck-maven-plugin</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <configuration>
@@ -245,7 +245,7 @@ The plugin generates spell check reports in the `target/spellcheck` directory:
 **Example configuration for Jenkins**:
 ```xml
 <plugin>
-    <groupId>com.github.tizuno</groupId>
+    <groupId>io.nncdevel.maven</groupId>
     <artifactId>spellcheck-maven-plugin</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <configuration>
@@ -282,7 +282,7 @@ stage('Spell Check') {
 **Example configuration for Jenkins Warnings NG**:
 ```xml
 <plugin>
-    <groupId>com.github.tizuno</groupId>
+    <groupId>io.nncdevel.maven</groupId>
     <artifactId>spellcheck-maven-plugin</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.tizuno</groupId>
+    <groupId>io.nncdevel.maven</groupId>
     <artifactId>spellcheck-maven-plugin</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>

--- a/src/main/java/io/nncdevel/maven/spellcheck/SpellCheckMojo.java
+++ b/src/main/java/io/nncdevel/maven/spellcheck/SpellCheckMojo.java
@@ -1,11 +1,11 @@
-package com.github.tizuno.maven.spellcheck;
+package io.nncdevel.maven.spellcheck;
 
-import com.github.tizuno.maven.spellcheck.config.CSpellConfig;
-import com.github.tizuno.maven.spellcheck.config.CSpellConfigLoader;
-import com.github.tizuno.maven.spellcheck.config.SpellCheckConfiguration;
-import com.github.tizuno.maven.spellcheck.report.CheckstyleXmlReportGenerator;
-import com.github.tizuno.maven.spellcheck.report.JUnitXmlReportGenerator;
-import com.github.tizuno.maven.spellcheck.report.SpellCheckReport;
+import io.nncdevel.maven.spellcheck.config.CSpellConfig;
+import io.nncdevel.maven.spellcheck.config.CSpellConfigLoader;
+import io.nncdevel.maven.spellcheck.config.SpellCheckConfiguration;
+import io.nncdevel.maven.spellcheck.report.CheckstyleXmlReportGenerator;
+import io.nncdevel.maven.spellcheck.report.JUnitXmlReportGenerator;
+import io.nncdevel.maven.spellcheck.report.SpellCheckReport;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;

--- a/src/main/java/io/nncdevel/maven/spellcheck/SpellChecker.java
+++ b/src/main/java/io/nncdevel/maven/spellcheck/SpellChecker.java
@@ -1,8 +1,8 @@
-package com.github.tizuno.maven.spellcheck;
+package io.nncdevel.maven.spellcheck;
 
-import com.github.tizuno.maven.spellcheck.config.SpellCheckConfiguration;
-import com.github.tizuno.maven.spellcheck.report.SpellCheckReport;
-import com.github.tizuno.maven.spellcheck.report.SpellError;
+import io.nncdevel.maven.spellcheck.config.SpellCheckConfiguration;
+import io.nncdevel.maven.spellcheck.report.SpellCheckReport;
+import io.nncdevel.maven.spellcheck.report.SpellError;
 import org.apache.maven.plugin.logging.Log;
 import org.languagetool.JLanguageTool;
 import org.languagetool.language.AmericanEnglish;

--- a/src/main/java/io/nncdevel/maven/spellcheck/config/CSpellConfig.java
+++ b/src/main/java/io/nncdevel/maven/spellcheck/config/CSpellConfig.java
@@ -1,4 +1,4 @@
-package com.github.tizuno.maven.spellcheck.config;
+package io.nncdevel.maven.spellcheck.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/io/nncdevel/maven/spellcheck/config/CSpellConfigLoader.java
+++ b/src/main/java/io/nncdevel/maven/spellcheck/config/CSpellConfigLoader.java
@@ -1,4 +1,4 @@
-package com.github.tizuno.maven.spellcheck.config;
+package io.nncdevel.maven.spellcheck.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.maven.plugin.logging.Log;

--- a/src/main/java/io/nncdevel/maven/spellcheck/config/SpellCheckConfiguration.java
+++ b/src/main/java/io/nncdevel/maven/spellcheck/config/SpellCheckConfiguration.java
@@ -1,4 +1,4 @@
-package com.github.tizuno.maven.spellcheck.config;
+package io.nncdevel.maven.spellcheck.config;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/src/main/java/io/nncdevel/maven/spellcheck/report/CheckstyleXmlReportGenerator.java
+++ b/src/main/java/io/nncdevel/maven/spellcheck/report/CheckstyleXmlReportGenerator.java
@@ -1,4 +1,4 @@
-package com.github.tizuno.maven.spellcheck.report;
+package io.nncdevel.maven.spellcheck.report;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/src/main/java/io/nncdevel/maven/spellcheck/report/JUnitXmlReportGenerator.java
+++ b/src/main/java/io/nncdevel/maven/spellcheck/report/JUnitXmlReportGenerator.java
@@ -1,4 +1,4 @@
-package com.github.tizuno.maven.spellcheck.report;
+package io.nncdevel.maven.spellcheck.report;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/src/main/java/io/nncdevel/maven/spellcheck/report/SpellCheckReport.java
+++ b/src/main/java/io/nncdevel/maven/spellcheck/report/SpellCheckReport.java
@@ -1,4 +1,4 @@
-package com.github.tizuno.maven.spellcheck.report;
+package io.nncdevel.maven.spellcheck.report;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/src/main/java/io/nncdevel/maven/spellcheck/report/SpellError.java
+++ b/src/main/java/io/nncdevel/maven/spellcheck/report/SpellError.java
@@ -1,4 +1,4 @@
-package com.github.tizuno.maven.spellcheck.report;
+package io.nncdevel.maven.spellcheck.report;
 
 import java.io.File;
 import java.util.List;

--- a/src/test/java/io/nncdevel/maven/spellcheck/SpellCheckMojoTest.java
+++ b/src/test/java/io/nncdevel/maven/spellcheck/SpellCheckMojoTest.java
@@ -1,4 +1,4 @@
-package com.github.tizuno.maven.spellcheck;
+package io.nncdevel.maven.spellcheck;
 
 import org.apache.maven.plugin.testing.MojoRule;
 import org.apache.maven.plugin.testing.WithoutMojo;

--- a/src/test/java/io/nncdevel/maven/spellcheck/config/CSpellConfigLoaderTest.java
+++ b/src/test/java/io/nncdevel/maven/spellcheck/config/CSpellConfigLoaderTest.java
@@ -1,4 +1,4 @@
-package com.github.tizuno.maven.spellcheck.config;
+package io.nncdevel.maven.spellcheck.config;
 
 import org.apache.maven.plugin.logging.Log;
 import org.junit.Before;

--- a/src/test/java/io/nncdevel/maven/spellcheck/report/CheckstyleXmlReportGeneratorTest.java
+++ b/src/test/java/io/nncdevel/maven/spellcheck/report/CheckstyleXmlReportGeneratorTest.java
@@ -1,4 +1,4 @@
-package com.github.tizuno.maven.spellcheck.report;
+package io.nncdevel.maven.spellcheck.report;
 
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/io/nncdevel/maven/spellcheck/report/JUnitXmlReportGeneratorTest.java
+++ b/src/test/java/io/nncdevel/maven/spellcheck/report/JUnitXmlReportGeneratorTest.java
@@ -1,4 +1,4 @@
-package com.github.tizuno.maven.spellcheck.report;
+package io.nncdevel.maven.spellcheck.report;
 
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/io/nncdevel/maven/spellcheck/report/SpellCheckReportTest.java
+++ b/src/test/java/io/nncdevel/maven/spellcheck/report/SpellCheckReportTest.java
@@ -1,4 +1,4 @@
-package com.github.tizuno.maven.spellcheck.report;
+package io.nncdevel.maven.spellcheck.report;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/resources/test-projects/simple-project/pom.xml
+++ b/src/test/resources/test-projects/simple-project/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.tizuno.test</groupId>
+    <groupId>io.nncdevel.maven.test</groupId>
     <artifactId>simple-project</artifactId>
     <version>1.0-SNAPSHOT</version>
 
@@ -15,7 +15,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.github.tizuno</groupId>
+                <groupId>io.nncdevel.maven</groupId>
                 <artifactId>spellcheck-maven-plugin</artifactId>
                 <version>1.0.0-SNAPSHOT</version>
                 <configuration>


### PR DESCRIPTION
- Change groupId from com.github.tizuno to io.nncdevel.maven
- Move all Java packages from com.github.tizuno.maven.spellcheck to io.nncdevel.maven.spellcheck
- Update package declarations and imports in all Java files
- Update Maven coordinates in pom.xml
- Update documentation (README.md, CLAUDE.md) with new Maven coordinates
- Update test project configuration with new groupId

This change establishes a new organizational namespace for the project while maintaining all functionality.